### PR TITLE
bugfix preprocess

### DIFF
--- a/examples/dpo/qwen2/readme.md
+++ b/examples/dpo/qwen2/readme.md
@@ -43,7 +43,6 @@ bash ../../../scripts/msrun_launcher.sh \
 --src /path/to/input.jsonl \
 --dst /path/to/output.mindrecord \
 --config /path/to/mindrlhf/model_configs/qwen_config/process_qwen2_7b.yaml \
---auto_trans_ckpt True \
 --tokenizer /path/to/vocab.json \
 --merges_file /path/to/merges.txt \
 --seq_len 4097 \
@@ -69,7 +68,7 @@ bash ../../../scripts/msrun_launcher.sh \
 
 3. 推理
 
-   训练完成后，会存储下切片后的权重，如单机8卡的权重，但是在实际应用中，可能只需要单机单卡，就可以进行推理功能。考虑到性能的优势，一般推荐单机单卡进行推理，MindRLHF提供了权重转换的脚本(transform_checkpoint.py)，参考示例如下：
+训练完成后，会存储下切片后的权重，如单机8卡的权重，但是在实际应用中，可能只需要单机单卡，就可以进行推理功能。考虑到性能的优势，一般推荐单机单卡进行推理，MindRLHF提供了权重转换的脚本(transform_checkpoint.py)，参考示例如下：
 ```sh
 python transform_checkpoint.py \
    --src_checkpoint=/path/output/checkpoint_network \

--- a/model_configs/qwen_config/process_qwen2_7b.yaml
+++ b/model_configs/qwen_config/process_qwen2_7b.yaml
@@ -2,10 +2,10 @@ seed: 0
 output_dir: './output' # path to save checkpoint/strategy
 load_checkpoint: '/path/to/Qwen2-7B.ckpt'
 src_strategy_path_or_dir: ''
-auto_trans_ckpt: False  # If true, auto transform load_checkpoint to load in distributed model
+auto_trans_ckpt: True  # If true, auto transform load_checkpoint to load in distributed model
 only_save_strategy: False
 resume_training: False
-use_parallel: False
+use_parallel: True
 run_mode: 'predict'
 
 # trainer config


### PR DESCRIPTION
dpo_preprocess_qwen_parallel.py 没有处理auto_trans_ckpt的代码，删除命令行的auto_trans_ckpt选项，通过yaml的配置实现自动转换的功能。