### PR TITLE
bugfix dpo alpha beta param error

### DIFF
--- a/mindrlhf/models/glm4/glm_dpo.py
+++ b/mindrlhf/models/glm4/glm_dpo.py
@@ -338,4 +338,4 @@ class Glm4DPO(ChatGLM2ForConditionalGeneration):
             logits = self.reshape(logits, (bsz, tokens.shape[1], logits.shape[-1]))
         policy_logits = self.cast(logits, mstype.float32)
         dpo_loss, sft_loss = self.dpo_loss(policy_logits, labels, chosen_loss_mask, rejected_loss_mask, chosen_ref_logps.reshape((-1,)), rejected_ref_logps.reshape((-1,)))
-        return self.alpha * dpo_loss + self.beta * sft_loss
+        return dpo_loss + self.alpha * sft_loss

--- a/mindrlhf/models/qwen2/qwen_dpo.py
+++ b/mindrlhf/models/qwen2/qwen_dpo.py
@@ -378,4 +378,4 @@ class Qwen7BDPO(LlamaForCausalLM):
             logits = self.reshape(logits, (bsz, tokens.shape[1], logits.shape[-1]))
         policy_logits = self.cast(logits, mstype.float32)
         dpo_loss, sft_loss = self.dpo_loss(policy_logits, labels, chosen_loss_mask, rejected_loss_mask, chosen_ref_logps.reshape((-1,)), rejected_ref_logps.reshape((-1,)))
-        return self.alpha * dpo_loss + self.beta * sft_loss
+        return  dpo_loss + self.alpha * sft_loss

--- a/mindrlhf/models/qwen2_5/qwen_dpo.py
+++ b/mindrlhf/models/qwen2_5/qwen_dpo.py
@@ -378,4 +378,4 @@ class Qwen2_5_7BDPO(LlamaForCausalLM):
             logits = self.reshape(logits, (bsz, tokens.shape[1], logits.shape[-1]))
         policy_logits = self.cast(logits, mstype.float32)
         dpo_loss, sft_loss = self.dpo_loss(policy_logits, labels, chosen_loss_mask, rejected_loss_mask, chosen_ref_logps.reshape((-1,)), rejected_ref_logps.reshape((-1,)))
-        return self.alpha * dpo_loss + self.beta * sft_loss
+        return  dpo_loss + self.alpha * sft_loss

--- a/model_configs/glm_config/finetune_glm4_9b.yaml
+++ b/model_configs/glm_config/finetune_glm4_9b.yaml
@@ -75,8 +75,8 @@ model:
     qkv_concat: False
     mlp_concat: False
     use_llama_rope: True
-    alpha: 1.0  # coef for dpo loss
-    beta: 1.0   # coef for sft loss
+    alpha: 1.0  # coef for sft loss
+    beta: 1.0   # temperature of dpo loss in logsigmoid function
   arch:
     type: Glm4DPO
 

--- a/model_configs/glm_config/predict_glm4_9b.yaml
+++ b/model_configs/glm_config/predict_glm4_9b.yaml
@@ -75,8 +75,8 @@ model:
     qkv_concat: False
     mlp_concat: False
     use_llama_rope: True
-    alpha: 1.0  # coef for dpo loss
-    beta: 1.0   # coef for sft loss
+    alpha: 1.0  # coef for sft loss
+    beta: 1.0   # temperature of dpo loss in logsigmoid function
   arch:
     type: ChatGLM2ForConditionalGeneration
 

--- a/model_configs/glm_config/process_glm4_9b.yaml
+++ b/model_configs/glm_config/process_glm4_9b.yaml
@@ -75,8 +75,8 @@ model:
     qkv_concat: False
     mlp_concat: False
     use_llama_rope: True
-    alpha: 1.0  # coef for dpo loss
-    beta: 1.0   # coef for sft loss
+    alpha: 1.0  # coef for sft loss
+    beta: 1.0   # temperature of dpo loss in logsigmoid function
   arch:
     type: Glm4DPO
 

--- a/model_configs/glm_config/run_glm4_9b_rm.yaml
+++ b/model_configs/glm_config/run_glm4_9b_rm.yaml
@@ -75,8 +75,6 @@ model:
     qkv_concat: False
     mlp_concat: False
     use_llama_rope: True
-    alpha: 1.0  # coef for dpo loss
-    beta: 1.0   # coef for sft loss
   arch:
     type: Glm4RewardModel
 

--- a/model_configs/qwen_config/finetune_qwen2_5_7b_dpo.yaml
+++ b/model_configs/qwen_config/finetune_qwen2_5_7b_dpo.yaml
@@ -190,8 +190,8 @@ model:
     rotary_pct: 1.0
     rotary_emb_base: 1000000
     kv_channels: 128
-    alpha: 1.0  # coef for dpo loss
-    beta: 0.1   # coef for sft loss
+    alpha: 0.1  # coef for sft loss
+    beta: 1.0   # temperature of dpo loss in logsigmoid function
 
   arch:
     type: Qwen2_5_7BDPO

--- a/model_configs/qwen_config/finetune_qwen2_7b_dpo.yaml
+++ b/model_configs/qwen_config/finetune_qwen2_7b_dpo.yaml
@@ -190,9 +190,8 @@ model:
     rotary_pct: 1.0
     rotary_emb_base: 1000000
     kv_channels: 128
-    alpha: 1.0  # coef for dpo loss
-    beta: 0.1   # coef for sft loss
-
+    alpha: 0.1  # coef for sft loss
+    beta: 1.0   # temperature of dpo loss in logsigmoid function
   arch:
     type: Qwen7BDPO
 


### PR DESCRIPTION
修改后：
1. dpo_loss 和 sft_loss 加权时，dpo_loss的权重固定为1，alpha作为stf_loss可调节。
2. beta参数，专门作用在loss计算时，dpo_loss传入logsigmoid函数前的权重。